### PR TITLE
Update comment about using OpenFileSequential

### DIFF
--- a/pkg/cli/image/archive/archive.go
+++ b/pkg/cli/image/archive/archive.go
@@ -323,7 +323,7 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 		}
 
 	case tar.TypeReg, tar.TypeRegA:
-		// Source is regular file. We use system.OpenFileSequential to use sequential
+		// Source is regular file. We use system.OpenFile to use sequential
 		// file access to avoid depleting the standby list on Windows.
 		// On Linux, this equates to a regular os.OpenFile
 		file, err := sequential.OpenFile(path, os.O_CREATE|os.O_WRONLY, hdrInfo.Mode())


### PR DESCRIPTION
A previous commit refactored OpenFileSequential since it was deprecated, and replaced it with OpenFile.

  https://github.com/openshift/oc/commit/7a8c458fbbf06a1c8411e4199d61e6d43bf67334

This commit just updates the comment to be accurate, since I stumbled on it walking through the code.